### PR TITLE
runner: mkdir -p temp dir

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -214,7 +214,7 @@ func (r *Runner) Run() error {
 	log.Printf("submitting map reduce job")
 
 	r.setTempPath()
-	if err := hdfs.Mkdir(r.tmpPath); err != nil {
+	if err := hdfs.FsCmd("-mkdir", "-p", r.tmpPath); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This switches to `mkdir -p` the temp directory path used which removes the need to manually create `/user/$user/tmp` ahead of time.