### PR TITLE
allow programs to set tmpPath

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -52,7 +52,9 @@ func (r *Runner) setTempPath() {
 		username = user.Username
 	}
 	now := time.Now().Format("20060102-150405")
-	r.tmpPath = fmt.Sprintf("/user/%s/tmp/%s.%s", username, r.Name, now)
+	if r.tmpPath == "" {
+		r.tmpPath = fmt.Sprintf("/user/%s/tmp/%s.%s", username, r.Name, now)
+	}
 }
 
 func (r *Runner) Cleanup() error {


### PR DESCRIPTION
@jehiah let me know if this approach seems OK. Figure an external program could set the tmpPath to `s3://` to leverage EMRFS.