### PR TITLE
dataproc support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ go:
   - 1.10.x
   - 1.11.x
 install:
-  - go get github.com/bmizerany/assert
+  - go get github.com/stretchr/testify/assert
   - go get github.com/bitly/go-simplejson
   - go get github.com/jehiah/lru
+  - go get -d golang.org/x/oauth2/google
 notifications:
   email: false
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
 # GoMRJob 
 
-A Go framework for Hadoop Map Reduce Jobs
+[![Build Status](https://secure.travis-ci.org/jehiah/gomrjobsvg?branch=master)][https://travis-ci.org/jehiah/gomrjob] [![GoDoc](https://godoc.org/github.com/jehiah/gomrjob?status.svg)](https://godoc.org/github.com/jehiah/gomrjob)
 
-[![Build Status](https://travis-ci.org/jehiah/gomrjob.png?branch=master)](https://travis-ci.org/jehiah/gomrjob)
+A Go framework for running Map Reduce Jobs on Hadoop.
 
 http://godoc.org/github.com/jehiah/gomrjob
 
-This framework is in production use at [Bitly](https://bitly.com/), but it's light on examples. See the [example](./example) for more context.
+### Supported Configurations
+
+* Hadoop with HDFS via `hadoop` CLI
+* [Google Cloud Dataproc](https://cloud.google.com/dataproc/) with [Google Storage](https://cloud.google.com/storage/)
+
+### About
+
+This framework has been in production use at [Bitly](https://bitly.com/) since 2013, but it's light on examples. 
+
+See the [example](./example) for more context.
+
+Heavily inspired by [`Yelp/mrjob`](https://github.com/Yelp/mrjob)

--- a/dataproc/job.go
+++ b/dataproc/job.go
@@ -1,0 +1,150 @@
+package dataproc
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/jehiah/gomrjob/hdfs"
+)
+
+func isTerminalState(s string) bool {
+	switch s {
+	case "ATTEMPT_FAILURE", "ERROR", "DONE", "CANCELLED":
+		return true
+	default:
+		return false
+	}
+}
+
+// https://cloud.google.com/dataproc/docs/reference/rest/v1beta2/projects.regions.jobs/submit
+type jobRequest struct {
+	RequestID string `json:"requestId,omitempty"`
+	Job       job    `json:"job"`
+}
+type job struct {
+	Placement struct {
+		ClusterName string `json:"cluster_name"`
+	} `json:"placement"`
+	Reference struct {
+		JobID string `json:"jobId,omitempty"`
+	} `json:"reference,omitempty"`
+	// https://cloud.google.com/dataproc/docs/reference/rest/v1beta2/HadoopJob
+	HadoopJob struct {
+		Args           []string          `json:"args"`
+		MainJarFileURI string            `json:"mainJarFileUri"`
+		FileURIs       []string          `json:"fileUris,omitempty"`
+		Properties     map[string]string `json:"properties,omitempty"`
+	} `json:"hadoopJob"`
+	Status struct {
+		State          string `json:"state,omitempty"`
+		StateStartTime string `json:"stateStartTime,omitempty"`
+		Details        string `json:"details,omitempty"`
+		SubState       string `json:"substate,omitempty"`
+	} `json:"status,omitempty"`
+}
+
+func SubmitJob(j hdfs.Job, client *http.Client, project, region, cluster string) error {
+	if j.Mapper == "" || j.Reducer == "" {
+		return errors.New("missing argument Mapper or Reducer")
+	}
+	p := make(map[string]string, len(j.Properties))
+	for k, v := range j.Properties {
+		p[k] = v
+	}
+	if _, ok := p["mapred.job.name"]; !ok {
+		p["mapred.job.name"] = j.Name
+	}
+	if _, ok := p["mapred.reduce.tasks"]; !ok {
+		p["mapred.reduce.tasks"] = fmt.Sprintf("%d", j.ReducerTasks)
+	}
+
+	var req jobRequest
+	req.Job.Reference.JobID = j.Name
+	req.Job.Placement.ClusterName = cluster
+	req.Job.HadoopJob.MainJarFileURI = "file:///usr/lib/hadoop-mapreduce/hadoop-streaming.jar"
+	req.Job.HadoopJob.Args = j.JarArgs()
+	req.Job.HadoopJob.FileURIs = j.CacheFiles
+	req.Job.HadoopJob.Properties = p
+
+	resource := fmt.Sprintf("https://dataproc.googleapis.com/v1/projects/%s/regions/%s/jobs:submit", url.PathEscape(project), url.PathEscape(region))
+	job, err := post(client, resource, req)
+	if err != nil {
+		return err
+	}
+	state := job.Status.State
+	log.Printf("job:%s status:%s", job.Reference.JobID, state)
+
+	resource = fmt.Sprintf("https://dataproc.googleapis.com/v1/projects/%s/regions/%s/jobs/%s", url.PathEscape(project), url.PathEscape(region), url.PathEscape(job.Reference.JobID))
+	ticker := time.NewTicker(time.Second * 2)
+	defer ticker.Stop()
+	var i int
+	for range ticker.C {
+		i++
+		job, err = get(client, resource)
+		if err != nil {
+			return err
+		}
+		// if state changes or 30s passes by
+		if state != job.Status.State || i%15 == 0 {
+			state = job.Status.State
+			log.Printf("job:%s status:%s", job.Reference.JobID, state)
+		}
+		if isTerminalState(state) {
+			break
+		}
+	}
+	return nil
+}
+
+func get(client *http.Client, resource string) (*job, error) {
+	resp, err := client.Get(resource)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		log.Print(string(respBody))
+		return nil, fmt.Errorf("got status code %d", resp.StatusCode)
+	}
+	var j job
+	return &j, json.Unmarshal(respBody, &j)
+}
+
+func post(client *http.Client, resource string, req jobRequest) (*job, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("Submitting job %q to Dataproc cluster %q", req.Job.Reference.JobID, req.Job.Placement.ClusterName)
+	log.Print(resource)
+	log.Printf("args: %q", req.Job.HadoopJob.Args)
+	for k, v := range req.Job.HadoopJob.Properties {
+		log.Printf("   -D %s=%v", k, v)
+	}
+	resp, err := client.Post(resource, "application/json", bytes.NewBuffer(body))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		log.Print(string(respBody))
+		return nil, fmt.Errorf("got status code %d", resp.StatusCode)
+	}
+	var j job
+	return &j, json.Unmarshal(respBody, &j)
+}

--- a/example/example_mr_test.go
+++ b/example/example_mr_test.go
@@ -15,16 +15,17 @@ func TestPutMessage(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 	log.SetOutput(os.Stdout)
 
-	step := &JsonEntryCounter{"key_field"}
+	step := &JsonEntryCounter{}
 	in := `{"key_field":"z"}
 			{"key_field":"a"}
 			{"key_field":"another"}
 			{"key_field":"z"}
 			{"key_field":"z"}
-			{"key_field":"a"}`
-	out := `"a"	2
-"another"	1
-"z"	3
+			{"another_key":"a"}
+`
+	out := `"another_key"	1
+"key_field"	5
+"lines_read"	6
 `
 	mrtest.TestMapReduceStep(t, step, bytes.NewBufferString(in), bytes.NewBufferString(out))
 }

--- a/hdfs/hadoop.go
+++ b/hdfs/hadoop.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
-	"fmt"
 	"io"
 	"log"
 	"os"
@@ -13,7 +12,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -203,17 +201,4 @@ type HdfsFile struct {
 	Size         int64
 	Modified     time.Time
 	Path         string
-}
-
-type hdfsFile string
-
-func (f hdfsFile) String() string {
-	switch {
-	case strings.HasPrefix(string(f), "hdfs://"):
-		return string(f)
-	case strings.HasPrefix(string(f), "s3://"):
-		return string(f)
-	default:
-		return fmt.Sprintf("hdfs://%s", string(f))
-	}
 }

--- a/hdfs/hadoop_test.go
+++ b/hdfs/hadoop_test.go
@@ -2,7 +2,7 @@ package hdfs
 
 import (
 	"bytes"
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 

--- a/hdfs/job_test.go
+++ b/hdfs/job_test.go
@@ -1,0 +1,27 @@
+package hdfs
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestAbsolutePath(t *testing.T) {
+	type testCase struct {
+		path, proto, expect string
+	}
+	tests := []testCase{
+		{"/a", "hdfs:///", "hdfs:///a"},
+		{"a", "hdfs:///", "hdfs:///a"},
+		{"/a", "", "hdfs:///a"},
+		{"hdfs:///a", "gs://bucket/", "hdfs:///a"},
+		{"gs://bucketa/a", "gs://bucketb/", "gs://bucketa/a"},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			got := absolutePath(tc.path, tc.proto)
+			if got != tc.expect {
+				t.Errorf("got %q expected %q for path %q proto %q", got, tc.expect, tc.path, tc.proto)
+			}
+		})
+	}
+}

--- a/internal/gcloud/gcloud.go
+++ b/internal/gcloud/gcloud.go
@@ -1,0 +1,28 @@
+package gcloud
+
+import (
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"io/ioutil"
+	"net/http"
+)
+
+const (
+	ScopeCloudPlatform string = "https://www.googleapis.com/auth/cloud-platform"
+	// https://cloud.google.com/storage/docs/json_api/v1/how-tos/authorizing
+	ScopeStorageReadWrite string = "https://www.googleapis.com/auth/devstorage.read_write"
+)
+
+// This reads a json service account credential file, and returns a http.Client that's bound to an
+// oauth2 access token for the provided scopes
+func LoadFromServiceJSON(serviceAccountPath string, scope ...string) (*http.Client, error) {
+	data, err := ioutil.ReadFile(serviceAccountPath)
+	if err != nil {
+		return nil, err
+	}
+	conf, err := google.JWTConfigFromJSON(data, scope...)
+	if err != nil {
+		return nil, err
+	}
+	return conf.Client(oauth2.NoContext), nil
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,0 +1,133 @@
+// simple functions for interacting with Google Storage over the JSON API
+//
+// This provides a no-dependency interaction with Google Storage
+// https://cloud.google.com/storage/docs/json_api
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+)
+
+const APIBase = "https://www.googleapis.com"
+
+// Insert using the "Simple Media" API
+// https://cloud.google.com/storage/docs/json_api/v1/how-tos/simple-upload
+func Insert(ctx context.Context, c *http.Client, bucket, name, contentType string, body io.Reader) error {
+	params := url.Values{"name": []string{name}}
+	endpoint := fmt.Sprintf("%s/upload/storage/v1/b/%s/o?%s", APIBase, url.PathEscape(bucket), params.Encode())
+	req, err := http.NewRequest("POST", endpoint, body)
+	if err != nil {
+		return err
+	}
+	req = req.WithContext(ctx)
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("got status code %d on upload of gs://%s/%s", resp.StatusCode, bucket, name)
+	}
+	return nil
+}
+
+// Object represents a single item in GS
+// https://cloud.google.com/storage/docs/json_api/v1/objects#resource
+type Object struct {
+	ID           string `json:"id"`
+	Bucket       string `json:"bucket"`
+	Name         string `json:"name"`
+	Size         int64  `json:"size"`
+	Created      string `json:"timeCreated"`
+	StorageClass string `json:"storageClass"`
+	MD5Hash      string `json:"md5Hash"`
+	Updateed     string `json:"updated"`
+}
+
+type listResp struct {
+	King          string   `json:"kind"` // storage#objects
+	NextPageToken string   `json:"nextPageToken"`
+	Prefixes      []string `json:"prefixes"`
+	Items         []Object `json:"items"`
+}
+
+// List returns up to 1k items matching a prefix
+// https://cloud.google.com/storage/docs/json_api/v1/objects/list
+// GET https://www.googleapis.com/storage/v1/b/bucket/o?prefix=....
+func List(ctx context.Context, c *http.Client, bucket, prefix, token string) (items []Object, pageToken string, err error) {
+	params := url.Values{"prefix": []string{prefix}}
+	if token != "" {
+		params.Set("pageToken", token)
+	}
+	endpoint := fmt.Sprintf("%s/storage/v1/b/%s/o?%s", APIBase, url.PathEscape(bucket), params.Encode())
+	req, err := http.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	req = req.WithContext(ctx)
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, "", fmt.Errorf("got status code %d on list of gs://%s/%s", resp.StatusCode, bucket, prefix)
+	}
+	var o listResp
+	if err := json.NewDecoder(resp.Body).Decode(&o); err != nil {
+		return nil, "", err
+	}
+	return o.Items, o.NextPageToken, nil
+}
+
+// Delete
+// https://cloud.google.com/storage/docs/json_api/v1/objects/delete?authuser=1
+func Delete(ctx context.Context, c *http.Client, bucket, name string) error {
+	log.Printf("deleting gs://%s/%s", bucket, name)
+	endpoint := fmt.Sprintf("%s/storage/v1/b/%s/o/%s", APIBase, url.PathEscape(bucket), url.PathEscape(name))
+	req, err := http.NewRequest("DELETE", endpoint, nil)
+	if err != nil {
+		return err
+	}
+	req = req.WithContext(ctx)
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("got status code %d on delete of gs://%s/%s", resp.StatusCode, bucket, name)
+	}
+	return nil
+}
+
+func DeletePrefix(ctx context.Context, c *http.Client, bucket, prefix string) error {
+	items, token, err := List(ctx, c, bucket, prefix, "")
+	if err != nil {
+		return err
+	}
+	if len(items) == 0 {
+		return nil
+	}
+	for token != "" {
+		for _, obj := range items {
+			if err := Delete(ctx, c, bucket, obj.Name); err != nil {
+				return err
+			}
+		}
+		items, token, err = List(ctx, c, bucket, prefix, token)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/mrproto/protocol_test.go
+++ b/mrproto/protocol_test.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestJsonInputProtocol(t *testing.T) {

--- a/remote_logger_test.go
+++ b/remote_logger_test.go
@@ -3,7 +3,7 @@ package gomrjob
 import (
 	"testing"
 
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestListen(t *testing.T) {

--- a/runner.go
+++ b/runner.go
@@ -1,46 +1,106 @@
 package gomrjob
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"os"
 	"os/user"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/jehiah/gomrjob/dataproc"
 	"github.com/jehiah/gomrjob/hdfs"
+	"github.com/jehiah/gomrjob/internal/gcloud"
+	"github.com/jehiah/gomrjob/internal/storage"
 )
 
 var (
+	submitJob = flag.Bool("submit-job", false, "submit the job")
+
+	// internal flags used by the map-reduce steps
 	stage        = flag.String("stage", "", "map,reduce")
 	step         = flag.Int("step", 0, "the step to execute")
 	remoteLogger = flag.String("remote-logger", "", "address for remote logger")
-	submitJob    = flag.Bool("submit-job", false, "submit the job")
+
+	// flags for Dataproc support
+	bucket         = flag.String("bucket", "", "Google Storage bucket to use | GS_BUCKET")
+	project        = flag.String("project", "", "Google Cloud Project ID | GS_PROJECT")
+	cluster        = flag.String("cluster", "", "Dataproc cluster | GS_CLUSTER")
+	region         = flag.String("region", "", "Dataproc region | GS_REGION")
+	serviceAccount = flag.String("service_account", "", "Google Storage Service Account JSON | GOOGLE_APPLICATION_CREDENTIALS")
 )
+
+type JobType int8
+
+const (
+	HDFS JobType = iota
+	Dataproc
+)
+
+const executibleName = "gomrjob_binary" // The filenamename used for the executible when uploaded
 
 type Runner struct {
 	Name  string
 	Steps []Step
 	// Inputfiles can be of the format `/pattern/to/files*.gz` or `hdfs:///pattern/to/files*.gz` or `s3://bucket/pattern`
 	InputFiles         []string
-	Output             string
+	Output             string // fully qualified
 	ReducerTasks       int
 	PassThroughOptions []string // CLI arguments to $exe when run as map / reduce tasks
-	tmpPath            string
-	exePath            string
 	CompressOutput     bool
-	Files              []string
+	CacheFiles         []string          // -files
+	Files              []string          // -file
 	Properties         map[string]string // -D key=value argumets to mapreduce-streaming.jar
+	JobType            JobType
+
+	defaultProto string
+	tmpPath      string
+	gcloud       *http.Client
+}
+
+// LoadAndValidateFlags loads flags from env and checks for missing arguments
+func LoadAndValidateFlags() {
+	// bootstrap missing flags from environment (if set)
+	for env, target := range map[string]*string{
+		"GOOGLE_APPLICATION_CREDENTIALS": serviceAccount,
+		"GS_REGION":                      region,
+		"GS_PROJECT":                     project,
+		"GS_CLUSTER":                     cluster,
+		"GS_BUCKET":                      bucket,
+	} {
+		if have := os.Getenv(env); have != "" && *target == "" {
+			*target = have
+		}
+	}
+
+	if *serviceAccount == "" {
+		return
+	}
+
+	switch {
+	case *project == "":
+		log.Fatal("missing --project")
+	case *cluster == "":
+		log.Fatal("missing --cluster")
+	case *region == "":
+		log.Fatal("missing --region")
+	case *bucket == "":
+		log.Fatal("missing --bucket")
+	}
 }
 
 func NewRunner() *Runner {
 	r := &Runner{
 		ReducerTasks: 30,
-		Properties: make(map[string]string),
+		Properties:   make(map[string]string),
+		JobType:      HDFS,
+		defaultProto: "hdfs:///",
 	}
 	r.setTempPath()
 	return r
@@ -53,13 +113,20 @@ func (r *Runner) setTempPath() {
 		username = user.Username
 	}
 	now := time.Now().Format("20060102-150405")
-	r.tmpPath = fmt.Sprintf("/user/%s/tmp/%s.%s", username, r.Name, now)
+	r.tmpPath = fmt.Sprintf("user/%s/tmp/%s.%s", username, r.Name, now)
 }
 
 func (r *Runner) Cleanup() error {
-	return hdfs.RMR(r.tmpPath)
+	switch r.JobType {
+	case HDFS:
+		return hdfs.RMR(r.tmpPath)
+	case Dataproc:
+		return storage.DeletePrefix(context.Background(), r.gcloud, *bucket, r.tmpPath)
+	}
+	panic("invalid job type")
 }
 
+// submitJob runs a single map/combine/reduce job.
 func (r *Runner) submitJob(loggerAddress string, stepNumber int, step Step) error {
 	if stepNumber >= len(r.Steps) || len(r.Steps) == 0 {
 		return fmt.Errorf("step %d out of range", stepNumber)
@@ -83,13 +150,12 @@ func (r *Runner) submitJob(loggerAddress string, stepNumber int, step Step) erro
 		input = append(input, fmt.Sprintf("%s/step_%d/output/part-*", r.tmpPath, stepNumber-1))
 	}
 
-	processName := filepath.Base(r.exePath)
-	taskOptions := r.PassThroughOptions[:]
+	taskOptions := append([]string{executibleName}, r.PassThroughOptions...)
 	if loggerAddress != "" {
 		taskOptions = append(taskOptions, fmt.Sprintf("--remote-logger=%s", loggerAddress))
 	}
 	taskOptions = append(taskOptions, fmt.Sprintf("--step=%d", stepNumber))
-	taskString := fmt.Sprintf("%s %s", processName, strings.Join(taskOptions, " "))
+	taskString := strings.Join(taskOptions, " ")
 
 	if r.CompressOutput {
 		r.Properties["mapred.output.compress"] = "true"
@@ -101,7 +167,7 @@ func (r *Runner) submitJob(loggerAddress string, stepNumber int, step Step) erro
 		name = fmt.Sprintf("%s-step_%d", name, stepNumber)
 	}
 
-	// specify reducer tasks per step
+	// StepReducerTasksCount interface overrides reducer tasks per step
 	reducerTasks := r.ReducerTasks
 	if step, ok := step.(StepReducerTasksCount); ok {
 		reducerTasks = step.NumberReducerTasks()
@@ -109,7 +175,6 @@ func (r *Runner) submitJob(loggerAddress string, stepNumber int, step Step) erro
 
 	j := hdfs.Job{
 		Name:         name,
-		CacheFiles:   []string{fmt.Sprintf("hdfs://%s#%s", r.exePath, processName)},
 		ReducerTasks: reducerTasks,
 		Input:        input,
 		Output:       output,
@@ -117,24 +182,58 @@ func (r *Runner) submitJob(loggerAddress string, stepNumber int, step Step) erro
 		Reducer:      fmt.Sprintf("%s --stage=reducer", taskString),
 		Files:        r.Files,
 		Properties:   r.Properties,
+		CacheFiles:   r.CacheFiles,
+		DefaultProto: r.defaultProto,
 	}
 	if _, ok := step.(Combiner); ok {
 		j.Combiner = fmt.Sprintf("%s --stage=combiner", taskString)
 	}
-	return hdfs.SubmitJob(j)
+	switch r.JobType {
+	case HDFS:
+		return hdfs.SubmitJob(j)
+	case Dataproc:
+		return dataproc.SubmitJob(j, r.gcloud, *project, *region, *cluster)
+	default:
+		panic("unknown job type")
+	}
 }
 
 func (r *Runner) copyRunningBinaryToHdfs() error {
 	// copy the current executible binary to hadoop for use as the map reduce tasks
-	r.exePath = fmt.Sprintf("%s/%s", r.tmpPath, "gomrjob_binary")
 	localExePath, err := filepath.EvalSymlinks("/proc/self/exe")
 	if err != nil {
 		return fmt.Errorf("failed locating running executable %s", err)
 	}
-	if err := hdfs.Put(localExePath, r.exePath); err != nil {
-		return fmt.Errorf("error copying %s to hdfs %s", r.exePath, err)
+	exePath := fmt.Sprintf("%s/%s", r.tmpPath, executibleName)
+	if err := hdfs.Put(localExePath, exePath); err != nil {
+		return fmt.Errorf("error copying %s to hdfs %s", exePath, err)
 	}
+	r.CacheFiles = append(r.CacheFiles, fmt.Sprintf("%s%s#%s", r.defaultProto, exePath, executibleName))
 	return nil
+}
+
+func (r *Runner) cacheFileInGoogleStorage(ctx context.Context, src, target string) error {
+	f, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	cachedFile := fmt.Sprintf("gs://%s/%s", *bucket, target)
+	log.Printf("uploading %s as %s", src, cachedFile)
+
+	var contentType string
+	err = storage.Insert(ctx, r.gcloud, *bucket, target, contentType, f)
+	if err != nil {
+		return err
+	}
+
+	r.CacheFiles = append(r.CacheFiles, cachedFile)
+	return nil
+}
+
+func (r *Runner) copyRunningBinaryToDataproc(ctx context.Context) error {
+	exePath := fmt.Sprintf("%s/%s", r.tmpPath, executibleName)
+	return r.cacheFileInGoogleStorage(ctx, "/proc/self/exe", exePath)
 }
 
 // return which stage the runner is executing as
@@ -149,6 +248,10 @@ func (r *Runner) Stage() string {
 	return "unknown"
 }
 
+// Run is the program entry point from main()
+//
+// When executed directly (--stage='') uploads loads the executibile
+// and submits mapreduce jobs for each stage of the program
 func (r *Runner) Run() error {
 	if *step >= len(r.Steps) {
 		return fmt.Errorf("invalid --step=%d (max %d)", *step, len(r.Steps))
@@ -205,21 +308,45 @@ func (r *Runner) Run() error {
 		return errors.New("missing --submit-job")
 	}
 
-	log.Print("submitting map reduce job")
-
 	r.setTempPath()
-	if err := hdfs.FsCmd("-mkdir", "-p", r.tmpPath); err != nil {
-		return err
+	LoadAndValidateFlags()
+	if *serviceAccount != "" {
+		r.gcloud, err = gcloud.LoadFromServiceJSON(*serviceAccount, gcloud.ScopeCloudPlatform, gcloud.ScopeStorageReadWrite)
+		if err != nil {
+			log.Fatal(err)
+		}
+		r.JobType = Dataproc
+		r.defaultProto = fmt.Sprintf("gs://%s/", *bucket)
 	}
 
-	if err := r.copyRunningBinaryToHdfs(); err != nil {
-		return err
+	switch r.JobType {
+	case HDFS:
+		if err := hdfs.FsCmd("-mkdir", "-p", r.defaultProto+r.tmpPath); err != nil {
+			return err
+		}
+		if err := r.copyRunningBinaryToHdfs(); err != nil {
+			return err
+		}
+	case Dataproc:
+		ctx := context.Background()
+		if err := r.copyRunningBinaryToDataproc(ctx); err != nil {
+			return err
+		}
+		// since -file on the hadoop-streaming.jar submission doesn't refer to a local file
+		// we need to upload the files to Google Storage and use CacheFiles
+		for _, f := range r.Files {
+			target := fmt.Sprintf("%s/%s", r.tmpPath, filepath.Base(f))
+			if err := r.cacheFileInGoogleStorage(ctx, f, target); err != nil {
+				return err
+			}
+		}
+		r.Files = []string{}
 	}
 
 	loggerAddress := startRemoteLogListner()
 
 	if r.Output == "" {
-		r.Output = fmt.Sprintf("%s/output", r.tmpPath)
+		r.Output = fmt.Sprintf("%s%s/output", r.defaultProto, r.tmpPath)
 	}
 
 	for stepNumber, step := range r.Steps {


### PR DESCRIPTION
This adds support for [Google Cloud Dataproc](https://cloud.google.com/dataproc/) with the following command line options

```
-bucket string
	Google Storage bucket to use
-cluster string
	Dataproc cluster
-project string
	Google Cloud Project ID
-region string
	Dataproc region
-service_account string
	Google Storage Service Account JSON
```

or the matching environment variables

```
GS_BUCKET
GS_CLUSTER
GS_PROJECT
GS_REGION
GOOGLE_APPLICATION_CREDENTIALS
```