### PR TITLE
runner: refactor property arguments as map[string]string

### DIFF
--- a/hdfs/hadoop.go
+++ b/hdfs/hadoop.go
@@ -217,4 +217,3 @@ func (f hdfsFile) String() string {
 		return fmt.Sprintf("hdfs://%s", string(f))
 	}
 }
-


### PR DESCRIPTION
In support of #10 this refactors the properties sent along to mapreduce-streaming.jar to disambiguate between generic options (properties) which must come first and arguments specific to `hadoop-streaming.jar`